### PR TITLE
Remove leading space in MX-28

### DIFF
--- a/public/data/pedals.json
+++ b/public/data/pedals.json
@@ -36,7 +36,7 @@
     },
     {
         "Brand":"Rolls",
-        "Name":" MX28 Stereo Mini-Mix VI",
+        "Name":"MX28 Stereo Mini-Mix VI",
         "Width":4.25,
         "Height":4.5,
         "Image":"rolls-mx28.png"


### PR DESCRIPTION
Leading space in name doesn't seem to impact anything, but nice to clean up. @tehtrav 