### PR TITLE
Feature/import export pedal canvas

### DIFF
--- a/app/scripts/scripts.js
+++ b/app/scripts/scripts.js
@@ -439,7 +439,7 @@ function setPedalCanvas(pedalCanvas) {
 		localStorage["pedalCanvas"] = pedalCanvas;
 		loadPedalCanvas();
 	} catch (err) {
-		console.log("Error importing file");
+		console.log("Error setting pedalCanvas");
 	}
 }
 

--- a/app/scripts/scripts.js
+++ b/app/scripts/scripts.js
@@ -37,13 +37,11 @@ $(document).ready(function(){
 		input.onchange = e => { 
 			// getting a hold of the file reference
 			var file = e.target.files[0];
-			// setting up the reader
 			var reader = new FileReader();
-			reader.readAsBinaryString(file); // this is reading as data url
-			// here we tell the reader what to do when it's done reading...
+			reader.readAsBinaryString(file);
 			reader.onload = readerEvent => {
-			var content = readerEvent.target.result; // this is the content!
-			importPedalCanvas(content);
+			var content = readerEvent.target.result;
+			setPedalCanvas(content);
 		   }
 		}
 		input.click();
@@ -435,7 +433,7 @@ function loadPedalCanvas() {
 	}
 }
 
-function importPedalCanvas(pedalCanvas) {
+function setPedalCanvas(pedalCanvas) {
 	try {
 		console.log('saving imported pedals to canvas');
 		localStorage["pedalCanvas"] = pedalCanvas;

--- a/app/scripts/scripts.js
+++ b/app/scripts/scripts.js
@@ -30,31 +30,6 @@ $(document).ready(function(){
 		//$(this).val(null).trigger('change').focus();
 	});
 
-	$('body').on('click', '#import-canvas', function(){
-		var input = document.createElement('input');
-		input.type = 'file';
-		
-		input.onchange = e => { 
-			// getting a hold of the file reference
-			var file = e.target.files[0];
-			var reader = new FileReader();
-			reader.readAsBinaryString(file);
-			reader.onload = readerEvent => {
-			var content = readerEvent.target.result;
-			setPedalCanvas(content);
-		   }
-		}
-		input.click();
-	});
-
-	$('body').on('click', '#export-canvas', function() {
-		const file = exportPedalCanvas();
-		var link = document.createElement('a');
-		link.download = "pedal_playground_export.txt";
-		link.href = file;
-		link.click();
-	});
-
 	$(function() {
 		// Load canvas from localStorage if it has been saved prior
 		loadPedalCanvas();
@@ -130,8 +105,31 @@ $(document).ready(function(){
 
 	$('body').on('click', '#clear-canvas-confirmation', function(){
 		$(".canvas").empty();
-		$('#clear-canvas-modal').modal('hide')
+		$('#clear-canvas-modal').modal('hide');
 		savePedalCanvas();
+	});
+
+	$('body').on('click', '#import-canvas', function(){
+		var input = document.createElement('input');
+		input.type = 'file';
+		
+		input.onchange = e => { 
+			// getting a hold of the file reference
+			var file = e.target.files[0];
+			var reader = new FileReader();
+			reader.readAsBinaryString(file);
+			reader.onload = readerEvent => {
+			var content = readerEvent.target.result;
+			setPedalCanvas(content);
+		   }
+		}
+		input.click();
+	});
+	
+	$('body').on('click', '#download-exported-canvas-file-confirmation', function() {
+		exportPedalCanvas();
+		$(".canvas").focus();
+		$('#download-exported-canvas-file').modal('hide');
 	});
 
 	$('body').on('click', '#add-pedal button', function(event){
@@ -442,23 +440,23 @@ function setPedalCanvas(pedalCanvas) {
 		console.log("Error setting pedalCanvas");
 	}
 }
-
 function exportPedalCanvas() {
 	try {
 		console.log('Creating file to download');
 		var pedalCanvas = localStorage["pedalCanvas"];
 		var textFile = null;
 		var data = new Blob([pedalCanvas], {type: 'text/plain'});
-
-		// If we are replacing a previously generated file we need to
-		// manually revoke the object URL to avoid memory leaks.
+		// revoke the object URL of exisiting file to avoid memory leaks.
 		if (textFile !== null) {
-		window.URL.revokeObjectURL(textFile);
+			window.URL.revokeObjectURL(textFile);
 		}
-
 		textFile = window.URL.createObjectURL(data);
 
-		return textFile;
+		console.log('Downloading file');
+		var link = document.createElement('a');
+		link.download = "pedal_playground_export.txt";
+		link.href = textFile;
+		link.click();
 	} catch (err) {
 		console.log("Error exporting file");
 	}

--- a/app/scripts/scripts.js
+++ b/app/scripts/scripts.js
@@ -30,13 +30,36 @@ $(document).ready(function(){
 		//$(this).val(null).trigger('change').focus();
 	});
 
+	$('body').on('click', '#import-canvas', function(){
+		var input = document.createElement('input');
+		input.type = 'file';
+		
+		input.onchange = e => { 
+			// getting a hold of the file reference
+			var file = e.target.files[0];
+			// setting up the reader
+			var reader = new FileReader();
+			reader.readAsBinaryString(file); // this is reading as data url
+			// here we tell the reader what to do when it's done reading...
+			reader.onload = readerEvent => {
+			var content = readerEvent.target.result; // this is the content!
+			importPedalCanvas(content);
+		   }
+		}
+		input.click();
+	});
+
+	$('body').on('click', '#export-canvas', function() {
+		const file = exportPedalCanvas();
+		var link = document.createElement('a');
+		link.download = "pedal_playground_export.txt";
+		link.href = file;
+		link.click();
+	});
+
 	$(function() {
 		// Load canvas from localStorage if it has been saved prior
-		if (localStorage["pedalCanvas"] != null) {
-			var savedPedalCanvas = JSON.parse(localStorage["pedalCanvas"]);
-			$(".canvas").html(savedPedalCanvas);
-			readyCanvas();
-		}
+		loadPedalCanvas();
 
 		// If hidden multiplier value doesn't exist, create it
 		if($("#multiplier").length == 0) {
@@ -402,6 +425,45 @@ function readyCanvas(pedal) {
 function savePedalCanvas() {
 	console.log("Canvas Saved!");
 	localStorage["pedalCanvas"] = JSON.stringify($(".canvas").html());
+}
+
+function loadPedalCanvas() {
+	if (localStorage["pedalCanvas"] != null) {
+		var savedPedalCanvas = JSON.parse(localStorage["pedalCanvas"]);
+		$(".canvas").html(savedPedalCanvas);
+		readyCanvas();
+	}
+}
+
+function importPedalCanvas(pedalCanvas) {
+	try {
+		console.log('saving imported pedals to canvas');
+		localStorage["pedalCanvas"] = pedalCanvas;
+		loadPedalCanvas();
+	} catch (err) {
+		console.log("Error importing file");
+	}
+}
+
+function exportPedalCanvas() {
+	try {
+		console.log('Creating file to download');
+		var pedalCanvas = localStorage["pedalCanvas"];
+		var textFile = null;
+		var data = new Blob([pedalCanvas], {type: 'text/plain'});
+
+		// If we are replacing a previously generated file we need to
+		// manually revoke the object URL to avoid memory leaks.
+		if (textFile !== null) {
+		window.URL.revokeObjectURL(textFile);
+		}
+
+		textFile = window.URL.createObjectURL(data);
+
+		return textFile;
+	} catch (err) {
+		console.log("Error exporting file");
+	}
 }
 
 function rotatePedal(pedal) {

--- a/index.html
+++ b/index.html
@@ -119,6 +119,8 @@
 						</a>
 					</div>
 					<div class="sidebar__section">
+						<button id="import-canvas" class="btn btn-primary btn-block" data-target="#import-canvas-modal">Import</button>
+						<button id="export-canvas" class="btn btn-primary btn-block" data-target="#export-canvas-modal">Export</button>
 						<button id="clear-canvas" class="btn btn-sm btn-danger btn-block" data-toggle="modal" data-target="#clear-canvas-modal">Clear</button>
 					</div>
 				</div><!-- sidebar__scroll -->

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
 					</div>
 					<div class="sidebar__section">
 						<button id="import-canvas" class="btn btn-primary btn-block" data-target="#import-canvas-modal">Import</button>
-						<button id="export-canvas" class="btn btn-primary btn-block" data-target="#export-canvas-modal">Export</button>
+						<button id="export-canvas" class="btn btn-primary btn-block" data-toggle="modal" data-target="#download-exported-canvas-file">Export</button>
 						<button id="clear-canvas" class="btn btn-sm btn-danger btn-block" data-toggle="modal" data-target="#clear-canvas-modal">Clear</button>
 					</div>
 				</div><!-- sidebar__scroll -->
@@ -143,6 +143,23 @@
 					<div class="modal-footer">
 						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
 						<button type="button" class="btn btn-danger" id="clear-canvas-confirmation">Clear Canvas</button>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div id="download-exported-canvas-file" class="modal fade" tabindex="-1" role="dialog">
+			<div class="modal-dialog" role="document">
+				<div class="modal-content">
+					<div class="modal-header">
+						<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+						<h4 class="modal-title">Download Export</h4>
+					</div>
+					<div class="modal-body">
+						<p>This will download a file to your computer, are you sure?</p>
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+						<button type="button" class="btn btn-danger" id="download-exported-canvas-file-confirmation">Confirm Download</button>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Reason: I''ve been using the website a lot lately, and wanted to take sessions between computers. So I decided to take a stab at implementing an import/export of the pedalCanvas from local storage to to a text file and vice versa.

Files edited and changes made:
index.html
- added import button to sidebar__section
- added export button to sidebar__section
- added export confirmation based on the clear confirmation

scripts.js
- created setPedalCanvas: sets the canvas in local storage, and calls loadCanvas so they show up
- #import-canvas: import file selected from local file system, then calls setPedalCanvas 
- exportPedalCanvas: creates the text file from the contents of pedalCanvas in local storage, reates a download link, and clicks the link
- #download-exported-canvas-file-confirmation: exports and hides
- extracted the load from canvas functionality to loadPedalCanvas method for my own reuse.

Note: I'm not a front end dev, so sorry I've done anything funky.