### PR TITLE
Fix dimensions on Mission Expression pedal

### DIFF
--- a/public/data/pedals.json
+++ b/public/data/pedals.json
@@ -6435,8 +6435,8 @@
     {
         "Brand":"Mission",
         "Name":"EP1-L6",
-        "Width":3.5,
-        "Height":8.75,
+        "Width":4,
+        "Height":10,
         "Image":"mission-ep1-l6.png"
     },
     {


### PR DESCRIPTION
Previous measurements were based on the treadle on top of the pedal, not the base, so pedal appeared too small.