### PR TITLE
Fix Vertex Steel String mk2 size

### DIFF
--- a/public/data/pedals.json
+++ b/public/data/pedals.json
@@ -9388,8 +9388,8 @@
     {
         "Brand": "Vertex",
         "Name": "Steel String Clean Drive MKII",
-        "Width": 3.2,
-        "Height": 4.6,
+        "Width": 2.25,
+        "Height": 4.3,
         "Image": "vertex-steelstring-mk2.png"
     },
     {


### PR DESCRIPTION
There is an error in the SSmk2 manual, the size written down is for SSmk1.
The new values comes from Thomann.