### PR TITLE
add gulp bower scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,20 @@
 
 ## Running Locally
 
-0. Install node v10, bower, and gulp
-1. Install dependencies via `npm install`
-2. Install client-side libraries via `bower install`
-3. Compile assets and watch for changes via `gulp`
-4. Start the local server via `npm run serve`. This will open a browser tab for you at localhost:8080.
+0. Install node v10
+
+1. Install dependencies
+   * `npm install`
+
+2. Install client-side libraries
+   * `npm run bower install`
+
+3. Compile assets and watch for changes
+   * `npm run gulp`
+
+4. Start the local server
+   * `npm run serve`
+   * This will open a browser tab for you at localhost:8080.
 
 ### MacOS Notes
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
 		"prettier": "2.2.1"
 	},
 	"scripts": {
+		"bower": "bower --",
+		"gulp": "gulp --",
 		"serve": "http-server ./ -o",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},


### PR DESCRIPTION
Add bower and gulp to npm run scripts, e.g
- `npm run bower install`
- `npm run gulp`
- `npm run gulp scripts`

This eliminates the need to globally install gulp and bower or use explicit local path, e.g.
- `.\node_modules\.bin\bower install` 