### PR TITLE
Enhanced Fuzzy Search for Pedal/Pedalboard Selector

### DIFF
--- a/public/scripts/scripts.js
+++ b/public/scripts/scripts.js
@@ -9,10 +9,59 @@ $(document).ready(function () {
 	GetPedalBoardData();
 	convertUnits();
 
+	function pedalMatcher(params, data) {
+		if ($.trim(params.term) === '') {
+			return data;
+		}
+
+		function cleanString(str) {
+			return str.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+		}
+
+		var terms = params.term.split(/\s+/).filter(function(t) {
+			return t.length > 0;
+		});
+
+		function matchAllTerms(targetText) {
+			var cleanTarget = cleanString(targetText);
+			for (var i = 0; i < terms.length; i++) {
+				var cleanTerm = cleanString(terms[i]);
+				if (cleanTarget.indexOf(cleanTerm) === -1) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		if (matchAllTerms(data.text)) {
+			return data;
+		}
+
+		if (data.children && data.children.length > 0) {
+			var filteredChildren = [];
+
+			$.each(data.children, function (idx, child) {
+				var matchedChild = pedalMatcher(params, child);
+				if (matchedChild !== null) {
+					filteredChildren.push(matchedChild);
+				}
+			});
+
+			if (filteredChildren.length > 0) {
+				var modifiedData = $.extend({}, data, true);
+				modifiedData.children = filteredChildren;
+				return modifiedData;
+			}
+		}
+
+		return null;
+	}
+
 	// Make lists searchable
 	$(".pedal-list").select2({
 		placeholder: "Select a pedal",
 		width: "style",
+		matcher: pedalMatcher
 	});
 
 	$(".pedal-list").on("select2:select", function (e) {
@@ -24,6 +73,7 @@ $(document).ready(function () {
 	$(".pedalboard-list").select2({
 		placeholder: "Select a pedalboard",
 		width: "style",
+		matcher: pedalMatcher
 	});
 
 	$(".pedalboard-list").on("select2:select", function (e) {


### PR DESCRIPTION
# Improvement: Enhanced Fuzzy Search for Pedal Selector (Order-independent & Normalized)

## 📝 Summary
This PR updates the `pedalMatcher` function in the Select2 configuration to support **order-independent** and **special-character-agnostic** searching. This significantly improves the user experience by allowing users to find pedals without knowing the exact spelling, punctuation, or word order.

## 🚀 Motivation & Problem
Currently, the search function requires a strict substring match. This leads to poor UX in the following scenarios:

1.  **Special Characters:** Searching for `BD2` or `BD 2` does not find the **"BD-2"**. Users must type the exact hyphen.
2.  **Word Order:** Searching for `Big Muff Op` does not find **"Op-Amp Big Muff"**. Users must know the exact word order of the product name.
3.  **Brand + Model:** Searching for `Ibanez TS9` works, but `TS9 Ibanez` might fail depending on the string structure.

## 🛠 Implementation Details
I have implemented a custom matcher for Select2 (`pedalMatcher`) with the following logic:

1.  **Normalization:** Both the user input and the pedal data are normalized by removing all special characters (keeping only alphanumeric values) and converting to lowercase.
    * `BD-2` becomes `bd2`
    * `Tube Screamer` becomes `tubescreamer`
2.  **Tokenization:** The search term is split into individual tokens by spaces.
    * Input `Big Muff Op` becomes `['big', 'muff', 'op']`
3.  **"AND" Logic:** The matcher checks if **ALL** tokens are present in the target pedal name, regardless of their position.
4.  **Recursive Search:** The logic correctly handles the hierarchical data structure (Brand `optgroup` -> Pedal `option`) used by Select2.

## 🧪 Examples (Before vs. After)

| Search Input | Target Pedal Name | Before | **After (This PR)** |
| :--- | :--- | :--- | :--- |
| `BD2` | **Boss BD-2 Blues Driver** | ❌ Hidden | ✅ **Found** |
| `BD 2` | **Boss BD-2 Blues Driver** | ❌ Hidden | ✅ **Found** |
| `Big Muff Op` | **EHX Op-Amp Big Muff** | ❌ Hidden | ✅ **Found** |
| `TS9 Ibanez` | **Ibanez TS9 Tube Screamer** | ❌ Hidden | ✅ **Found** |

## 💻 Code Snippet Logic
```javascript
// Simplified logic representation
var terms = params.term.split(/\s+/); // Split by space
var match = terms.every(term => pedalName.includes(term)); // Check all terms
```
## ✅ Checklist
- [x] Tested with various pedal names containing hyphens (e.g., DD-7, BD-2).
- [x] Tested with multi-word searches in different orders.
- [x] Verified that brand headers and child items are filtered correctly.
- [x] No console errors during search.