### PR TITLE
Restore correct size for Pedaltrain Nano+

### DIFF
--- a/public/data/pedalboards.json
+++ b/public/data/pedalboards.json
@@ -1116,7 +1116,7 @@
 		"Brand": "Pedaltrain",
 		"Name": "Nano+",
 		"Width": 18,
-		"Height": 5.5,
+		"Height": 5,
 		"Image": "pedaltrain-nanoplus.png"
 	},
 	{


### PR DESCRIPTION
This reverses the change made in commit d37fcd418be0a44aa8d36bda36e95e95da976d90 and fixes #2330.